### PR TITLE
condsolidated datastore key generation to DatastoreKeyUtil.java

### DIFF
--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/fn/DocumentToEntityFn.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/fn/DocumentToEntityFn.java
@@ -1,13 +1,12 @@
 package edu.cuanschutz.ccp.tm_provider.etl.fn;
 
 import static com.google.datastore.v1.client.DatastoreHelper.makeValue;
-import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_KIND;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_CONTENT;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_FORMAT;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_ID;
-import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_TYPE;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_PIPELINE;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_PIPELINE_VERSION;
+import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_TYPE;
 
 import java.io.UnsupportedEncodingException;
 
@@ -16,11 +15,9 @@ import org.apache.beam.sdk.values.KV;
 
 import com.google.datastore.v1.Entity;
 import com.google.datastore.v1.Key;
-import com.google.datastore.v1.Key.Builder;
-import com.google.datastore.v1.Key.PathElement;
 import com.google.protobuf.ByteString;
 
-import edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreDocumentUtil;
+import edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreKeyUtil;
 import edu.cuanschutz.ccp.tm_provider.etl.util.DocumentFormat;
 import edu.cuanschutz.ccp.tm_provider.etl.util.DocumentType;
 import edu.cuanschutz.ccp.tm_provider.etl.util.PipelineKey;
@@ -85,10 +82,7 @@ public class DocumentToEntityFn extends DoFn<KV<String, String>, Entity> {
 
 	static Entity createEntity(String docId, DocumentType type, DocumentFormat format, PipelineKey pipeline,
 			String pipelineVersion, String docContent) throws UnsupportedEncodingException {
-		String docName = DatastoreDocumentUtil.getDocumentKeyName(docId, type, format, pipeline, pipelineVersion);
-		Builder builder = Key.newBuilder();
-		PathElement pathElement = builder.addPathBuilder().setKind(DOCUMENT_KIND).setName(docName).build();
-		Key key = builder.setPath(0, pathElement).build();
+		Key key = DatastoreKeyUtil.createDocumentKey(docId, type, format, pipeline, pipelineVersion);
 
 		/*
 		 * the document content is likely too large to store as a property, so we make
@@ -108,5 +102,6 @@ public class DocumentToEntityFn extends DoFn<KV<String, String>, Entity> {
 		Entity entity = entityBuilder.build();
 		return entity;
 	}
+
 
 }

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/fn/EtlFailureToEntityFn.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/fn/EtlFailureToEntityFn.java
@@ -1,7 +1,6 @@
 package edu.cuanschutz.ccp.tm_provider.etl.fn;
 
 import static com.google.datastore.v1.client.DatastoreHelper.makeValue;
-import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.FAILURE_KIND;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.FAILURE_PROPERTY_DOCUMENT_ID;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.FAILURE_PROPERTY_DOCUMENT_TYPE;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.FAILURE_PROPERTY_MESSAGE;
@@ -16,11 +15,10 @@ import org.apache.beam.sdk.transforms.DoFn;
 
 import com.google.datastore.v1.Entity;
 import com.google.datastore.v1.Key;
-import com.google.datastore.v1.Key.Builder;
-import com.google.datastore.v1.Key.PathElement;
 import com.google.protobuf.ByteString;
 
 import edu.cuanschutz.ccp.tm_provider.etl.EtlFailureData;
+import edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreKeyUtil;
 import edu.cuanschutz.ccp.tm_provider.etl.util.DocumentType;
 import edu.cuanschutz.ccp.tm_provider.etl.util.PipelineKey;
 import edu.ucdenver.ccp.common.file.CharacterEncoding;
@@ -57,11 +55,7 @@ public class EtlFailureToEntityFn extends DoFn<EtlFailureData, Entity> {
 	static Entity buildFailureEntity(PipelineKey pipeline, String pipelineVersion, DocumentType documentType,
 			String docId, String message, String stackTrace, com.google.cloud.Timestamp timestamp)
 			throws UnsupportedEncodingException {
-		String docName = String.format("%s.%s.%s.%s", docId, pipeline.name().toLowerCase(), pipelineVersion,
-				documentType.name());
-		Builder builder = Key.newBuilder();
-		PathElement pathElement = builder.addPathBuilder().setKind(FAILURE_KIND).setName(docName).build();
-		Key key = builder.setPath(0, pathElement).build();
+		Key key = DatastoreKeyUtil.createFailureKey(pipeline, pipelineVersion, documentType, docId);
 
 		/*
 		 * the stacktrace is likely too large to store as a property, so we make it a

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/fn/ProcessingStatusToEntityFn.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/fn/ProcessingStatusToEntityFn.java
@@ -1,7 +1,6 @@
 package edu.cuanschutz.ccp.tm_provider.etl.fn;
 
 import static com.google.datastore.v1.client.DatastoreHelper.makeValue;
-import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.STATUS_KIND;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.STATUS_PROPERTY_BERT_CHEBI_DONE;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.STATUS_PROPERTY_BERT_CL_DONE;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.STATUS_PROPERTY_BERT_GO_BP_DONE;
@@ -32,11 +31,9 @@ import org.apache.beam.sdk.transforms.DoFn;
 
 import com.google.datastore.v1.Entity;
 import com.google.datastore.v1.Key;
-import com.google.datastore.v1.Key.Builder;
-import com.google.datastore.v1.Key.PathElement;
 
 import edu.cuanschutz.ccp.tm_provider.etl.ProcessingStatus;
-import edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreProcessingStatusUtil;
+import edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreKeyUtil;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -60,10 +57,7 @@ public class ProcessingStatusToEntityFn extends DoFn<ProcessingStatus, Entity> {
 	}
 
 	static Entity buildStatusEntity(ProcessingStatus status) throws UnsupportedEncodingException {
-		String docName = DatastoreProcessingStatusUtil.getStatusKeyName(status.getDocumentId());
-		Builder builder = Key.newBuilder();
-		PathElement pathElement = builder.addPathBuilder().setKind(STATUS_KIND).setName(docName).build();
-		Key key = builder.setPath(0, pathElement).build();
+		Key key = DatastoreKeyUtil.createStatusKey(status.getDocumentId());
 
 		Entity.Builder entityBuilder = Entity.newBuilder();
 		entityBuilder.setKey(key);

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/util/DatastoreDocumentUtil.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/util/DatastoreDocumentUtil.java
@@ -3,6 +3,7 @@ package edu.cuanschutz.ccp.tm_provider.etl.util;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_KIND;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_CONTENT;
 import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_PROPERTY_ID;
+import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.STATUS_KIND;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +15,7 @@ import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.PathElement;
 
 /**
  * Utility for querying 'Documents' in Cloud Datastore.
@@ -23,9 +24,6 @@ public class DatastoreDocumentUtil {
 
 	// Create an authorized Datastore service using Application Default Credentials.
 	private final Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
-
-	// Create a Key factory to construct keys associated with this project.
-	private final KeyFactory keyFactory = datastore.newKeyFactory().setKind(DOCUMENT_KIND);
 
 	/**
 	 * @param documentIds
@@ -72,14 +70,8 @@ public class DatastoreDocumentUtil {
 	 */
 	public Key createDocumentKey(String docId, DocumentType type, DocumentFormat format, PipelineKey pipeline,
 			String pipelineVersion) {
-		String docName = getDocumentKeyName(docId, type, format, pipeline, pipelineVersion);
-		return keyFactory.newKey(docName);
+		String docName = DatastoreKeyUtil.getDocumentKeyName(docId, type, format, pipeline, pipelineVersion);
+		return datastore.newKeyFactory().addAncestor(PathElement.of(STATUS_KIND, DatastoreKeyUtil.getStatusKeyName(docId)))
+				.setKind(DOCUMENT_KIND).newKey(docName);
 	}
-
-	public static String getDocumentKeyName(String docId, DocumentType type, DocumentFormat format,
-			PipelineKey pipeline, String version) {
-		return String.format("%s.%s.%s.%s.%s", docId, type.name().toLowerCase(), format.name().toLowerCase(),
-				pipeline.name().toLowerCase(), version);
-	}
-
 }

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/util/DatastoreKeyUtil.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/util/DatastoreKeyUtil.java
@@ -1,0 +1,64 @@
+package edu.cuanschutz.ccp.tm_provider.etl.util;
+
+import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.DOCUMENT_KIND;
+import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.FAILURE_KIND;
+import static edu.cuanschutz.ccp.tm_provider.etl.util.DatastoreConstants.STATUS_KIND;
+
+import com.google.datastore.v1.Key;
+import com.google.datastore.v1.Key.Builder;
+import com.google.datastore.v1.Key.PathElement;
+
+public class DatastoreKeyUtil {
+
+	///////////////////////////////
+	//////// DOCUMENT KEY /////////
+	///////////////////////////////
+
+	public static String getDocumentKeyName(String docId, DocumentType type, DocumentFormat format,
+			PipelineKey pipeline, String version) {
+		return String.format("%s.%s.%s.%s.%s", docId, type.name().toLowerCase(), format.name().toLowerCase(),
+				pipeline.name().toLowerCase(), version);
+	}
+
+	public static Key createDocumentKey(String documentId, DocumentType type, DocumentFormat format,
+			PipelineKey pipeline, String pipelineVersion) {
+		String docName = getDocumentKeyName(documentId, type, format, pipeline, pipelineVersion);
+		Builder builder = Key.newBuilder();
+		PathElement statusElement = builder.addPathBuilder().setKind(STATUS_KIND).setName(getStatusKeyName(documentId))
+				.build();
+		PathElement documentElement = builder.addPathBuilder().setKind(DOCUMENT_KIND).setName(docName).build();
+		Key key = builder.setPath(0, statusElement).setPath(1, documentElement).build();
+		return key;
+	}
+
+	///////////////////////////////
+	///////// STATUS KEY //////////
+	///////////////////////////////
+
+	public static String getStatusKeyName(String docId) {
+		return String.format("%s.status", docId);
+	}
+
+	public static Key createStatusKey(String documentId) {
+		String docName = getStatusKeyName(documentId);
+		Builder builder = Key.newBuilder();
+		PathElement pathElement = builder.addPathBuilder().setKind(STATUS_KIND).setName(docName).build();
+		Key key = builder.setPath(0, pathElement).build();
+		return key;
+	}
+
+	///////////////////////////////
+	//////// FAILURE KEY /////////
+	///////////////////////////////
+
+	public static Key createFailureKey(PipelineKey pipeline, String pipelineVersion, DocumentType documentType,
+			String docId) {
+		String docName = String.format("%s.%s.%s.%s", docId, pipeline.name().toLowerCase(), pipelineVersion,
+				documentType.name());
+		Builder builder = Key.newBuilder();
+		PathElement pathElement = builder.addPathBuilder().setKind(FAILURE_KIND).setName(docName).build();
+		Key key = builder.setPath(0, pathElement).build();
+		return key;
+	}
+
+}

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/util/DatastoreProcessingStatusUtil.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/etl/util/DatastoreProcessingStatusUtil.java
@@ -22,7 +22,6 @@ import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Entity.Builder;
 import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.CompositeFilter;
@@ -41,9 +40,6 @@ public class DatastoreProcessingStatusUtil {
 
 	// Create an authorized Datastore service using Application Default Credentials.
 	private final Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
-
-	// Create a Key factory to construct keys associated with this project.
-	private final KeyFactory keyFactory = datastore.newKeyFactory().setKind(STATUS_KIND);
 
 	/**
 	 * @param targetProcessStatusFlag    The flag indicating the desired (target)
@@ -97,8 +93,8 @@ public class DatastoreProcessingStatusUtil {
 	 * @param statusFlag
 	 */
 	public void setStatusTrue(String docId, Set<ProcessingStatusFlag> statusFlags) {
-		String keyName = DatastoreProcessingStatusUtil.getStatusKeyName(docId);
-		Key key = keyFactory.newKey(keyName);
+		String keyName = DatastoreKeyUtil.getStatusKeyName(docId);
+		Key key = datastore.newKeyFactory().setKind(STATUS_KIND).newKey(keyName);
 
 		Transaction transaction = datastore.newTransaction();
 		try {
@@ -121,10 +117,6 @@ public class DatastoreProcessingStatusUtil {
 				transaction.rollback();
 			}
 		}
-	}
-
-	public static String getStatusKeyName(String docId) {
-		return String.format("%s.status", docId);
 	}
 
 	/**


### PR DESCRIPTION
Centralized key generation and also made documents children of their respective status entities within Datastore. This should allow for easier querying for all documents related to a single document ID.