### PR TITLE
add sentences-per-page parameter to the elasticsearch-to-brat export CLI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.12.7.1</version>
+				<version>2.10.5.1</version>
 			</dependency>
 
 			<dependency>

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/relation_extraction/ElasticsearchToBratExporter.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/relation_extraction/ElasticsearchToBratExporter.java
@@ -61,12 +61,6 @@ public class ElasticsearchToBratExporter {
 	private static final CharacterEncoding UTF8 = CharacterEncoding.UTF_8;
 
 	/**
-	 * To avoid the annotator having to switch pages in BRAT after annotating each
-	 * sentence, we will include multiple sentences on each page
-	 */
-	private static final int SENTENCES_PER_PAGE = 20;
-
-	/**
 	 * SEARCH_BATCH_SIZE is the number of records requested for each Elasticsearch
 	 * query
 	 */
@@ -94,17 +88,20 @@ public class ElasticsearchToBratExporter {
 	 * @param outputDirectory
 	 * @param biolinkAssociation
 	 * @param batchId
+	 * @param sentencesPerPage            determines how many sentences in each BRAT
+	 *                                    file, i.e., how many will show up on a
+	 *                                    single page in the BRAT UI
 	 * @param inputSentences
 	 * @param previousSentenceIdsFile
 	 * @param redundantSentencesToInclude
 	 * @throws IOException
 	 */
 	public static void createBratFiles(File outputDirectory, BiolinkAssociation biolinkAssociation, String batchId,
-			int batchSize, Collection<? extends TextDocument> inputSentences, Set<String> previousSentenceIds,
-			List<TextDocument> redundantSentencesToInclude) throws IOException {
+			int batchSize, int sentencesPerPage, Collection<? extends TextDocument> inputSentences,
+			Set<String> previousSentenceIds, List<TextDocument> redundantSentencesToInclude) throws IOException {
 
 		createBratFiles(outputDirectory, biolinkAssociation, batchId, batchSize, inputSentences, previousSentenceIds,
-				IDENTIFIERS_TO_EXCLUDE, SENTENCES_PER_PAGE, redundantSentencesToInclude);
+				IDENTIFIERS_TO_EXCLUDE, sentencesPerPage, redundantSentencesToInclude);
 	}
 
 	/**

--- a/src/main/java/edu/cuanschutz/ccp/tm_provider/relation_extraction/annot_batch_cli/BatchCreateCommand.java
+++ b/src/main/java/edu/cuanschutz/ccp/tm_provider/relation_extraction/annot_batch_cli/BatchCreateCommand.java
@@ -102,6 +102,10 @@ public class BatchCreateCommand implements Runnable {
 			"--concept-idf-file" }, required = true, description = "File with IDF values for all concepts.")
 	private File conceptIdfFile;
 
+	@Option(names = { "-g",
+			"--sentences-per-page" }, required = false, defaultValue = "20", description = "The number of sentences in each BRAT file, i.e., how many will show up on a single page in the BRAT UI")
+	private int sentencesPerPage;
+
 	@Override
 	public void run() {
 		createBatch();
@@ -165,7 +169,7 @@ public class BatchCreateCommand implements Runnable {
 			System.out.println("Search hits returned from Elastic: " + searchResults.size());
 
 			ElasticsearchToBratExporter.createBratFiles(batchDir, association, batchIdentifier, sentenceCount,
-					searchResults, alreadyInUseSentenceIds, redundantSentencesForAnnotation);
+					sentencesPerPage, searchResults, alreadyInUseSentenceIds, redundantSentencesForAnnotation);
 		} catch (IOException e) {
 			e.printStackTrace();
 			System.exit(-1);
@@ -189,7 +193,6 @@ public class BatchCreateCommand implements Runnable {
 			throws IOException {
 		Map<String, Set<String>> map = new HashMap<String, Set<String>>();
 
-		
 		// if the subject/object is a pairing of GO_BP and GO_CC, we cannot distinguish
 		// between the two in the search, so more development would be needed.
 		BiolinkClass subjectClass = association.getSubjectClass();
@@ -217,7 +220,7 @@ public class BatchCreateCommand implements Runnable {
 				conceptIdfFile);
 
 		System.out.println("******************** Filter map keys: " + map.keySet().toString());
-		
+
 		return map;
 	}
 


### PR DESCRIPTION
The sentences-per-page parameter is defined using `-g`. This parameter is optional with a default value of 20.

Note that this change is present in version 0.3 of the Docker container: `ucdenverccp/elastic2brat:0.3`